### PR TITLE
fix: 헤더 수정

### DIFF
--- a/src/main/java/com/HHive/hhive/domain/user/controller/UserController.java
+++ b/src/main/java/com/HHive/hhive/domain/user/controller/UserController.java
@@ -133,13 +133,15 @@ public class UserController {
     }
 
     @GetMapping("/kakao/callback")
-    public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+    public ResponseEntity<CommonResponse<String>> kakaoLogin(@RequestParam String code, HttpServletResponse response)
+            throws JsonProcessingException {
 
         // jwt 토큰 반환
         String token = kaKaoService.kakaoLogin(code);
 
-        response.setHeader(JwtUtil.AUTHORIZATION_HEADER, JwtUtil.BEARER_PREFIX + token);
+        response.setHeader(JwtUtil.AUTHORIZATION_HEADER, JwtUtil.BEARER_PREFIX + token.substring(7));
 
-        return "redirect:https://hhive.store/";
+        return ResponseEntity.ok()
+                .body(CommonResponse.of(HttpStatus.CREATED.value(), "카카오 로그인 성공", token));
     }
 }

--- a/src/test/java/com/HHive/hhive/domain/user/entity/UserTest.java
+++ b/src/test/java/com/HHive/hhive/domain/user/entity/UserTest.java
@@ -1,0 +1,109 @@
+package com.HHive.hhive.domain.user.entity;
+
+import com.HHive.hhive.domain.category.data.MajorCategory;
+import com.HHive.hhive.domain.category.data.SubCategory;
+import com.HHive.hhive.domain.user.dto.UpdateUserProfileRequestDTO;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("User Entity 테스트")
+class UserTest {
+
+    @Nested
+    @DisplayName("유저 정보 업데이트 테스트")
+    class UpdateUserInfoTest {
+
+        @Test
+        @DisplayName("카카오 ID 업데이트")
+        void kakaoIdUpdate() {
+            // given
+            User user = new User("testUser", "testPassword", "testEmail@email.com", "testDescription");
+            Long kakaoId = 12345678L;
+
+            // when
+            user.kakaoIdUpdate(kakaoId);
+
+            // then
+            assertEquals(kakaoId, user.getKakaoId());
+        }
+
+        @Test
+        @DisplayName("프로필 업데이트")
+        void updateProfile() {
+            // given
+            User user = new User("testUser", "testPassword", "testEmail@email.com", "testDescription");
+            UpdateUserProfileRequestDTO requestDTO = new UpdateUserProfileRequestDTO();
+
+            // when
+            user.updateProfile(requestDTO);
+
+            // then
+            assertEquals(requestDTO.getEmail(), user.getEmail());
+            assertEquals(requestDTO.getDescription(), user.getDescription());
+        }
+
+        @Test
+        @DisplayName("계정 삭제 업데이트")
+        void updateDeletedAt() {
+            // given
+            User user = new User("testUser", "testPassword", "testEmail@email.com", "testDescription");
+            assertFalse(user.is_deleted());
+
+            // when
+            user.updateDeletedAt();
+
+            // then
+            assertTrue(user.is_deleted());
+            assertNotNull(user.getDeletedAt());
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 정보 설정 테스트")
+    class SetUserInfoTest {
+
+        @Test
+        @DisplayName("비밀번호 설정")
+        void setPassword() {
+            // given
+            User user = new User("testUser", "testPassword", "testEmail@email.com", "testDescription");
+            String newPassword = "newPassword";
+
+            // when
+            user.setPassword(newPassword);
+
+            // then
+            assertEquals(newPassword, user.getPassword());
+        }
+
+        @Test
+        @DisplayName("major 카테고리 설정")
+        void setMajorCategory() {
+            // given
+            User user = new User("testUser", "testPassword", "testEmail@email.com", "testDescription");
+            MajorCategory majorCategory = MajorCategory.GAME;
+
+            // when
+            user.setMajorCategory(majorCategory);
+
+            // then
+            assertEquals(majorCategory, user.getMajorCategory());
+        }
+
+        @Test
+        @DisplayName("sub 카테고리 설정")
+        void setSubCategory() {
+            // given
+            User user = new User("testUser", "testPassword", "testEmail@email.com", "testDescription");
+            SubCategory subCategory = SubCategory.LOL;
+
+            // when
+            user.setSubCategory(subCategory);
+
+            // then
+            assertEquals(subCategory, user.getSubCategory());
+        }
+    }
+}
+


### PR DESCRIPTION
* 수정 전 Response header에서 bearer이 2번 뜨는 에러를 수정했어요
```
HTTP/1.1 200
Server: nginx/1.25.3
Date: Tue, 23 Jan 2024 13:59:30 GMT
Content-Type: text/html;charset=ISO-8859-1
Content-Length: 29
Connection: keep-alive
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Authorization: Bearer Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiLquYDsnYDssYQiLCJleHAiOjE3MDYwMjE5NzAsImlhdCI6MTcwNjAxODM3MH0.q7UCeigl7UqLhS0bVOU9ZvLFcIN7HTddteI6nzVOzek
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
```