### PR TITLE
feat: 이메일 인증 코드 검증

### DIFF
--- a/src/main/java/com/HHive/hhive/domain/user/dto/EmailCheckRequestDTO.java
+++ b/src/main/java/com/HHive/hhive/domain/user/dto/EmailCheckRequestDTO.java
@@ -12,4 +12,5 @@ import org.springframework.stereotype.Service;
 public class EmailCheckRequestDTO {
 
     private String email;
+    private String verificationCode;
 }

--- a/src/main/java/com/HHive/hhive/domain/user/entity/User.java
+++ b/src/main/java/com/HHive/hhive/domain/user/entity/User.java
@@ -2,7 +2,6 @@ package com.HHive.hhive.domain.user.entity;
 
 import com.HHive.hhive.domain.category.data.MajorCategory;
 import com.HHive.hhive.domain.category.data.SubCategory;
-import com.HHive.hhive.domain.user.dto.HobbyCategoryRequestDTO;
 import com.HHive.hhive.domain.user.dto.UpdateUserProfileRequestDTO;
 import com.HHive.hhive.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -53,6 +52,13 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private SubCategory subCategory;
 
+    // 이메일 인증 여부 필드 추가
+    @Column(nullable = false)
+    private boolean email_verified = false;
+
+    // 이메일 인증 코드 필드 추가
+    @Column
+    private String email_verification_code;
 
     public User(String username, String password, String email, String description) {
         this.username = username;
@@ -94,5 +100,20 @@ public class User extends BaseTimeEntity {
 
     public void setSubCategory(SubCategory subCategory) {
         this.subCategory = subCategory;
+    }
+
+    // 이메일 인증 상태를 업데이트하는 메서드 추가
+    public void setEmailVerified(boolean emailVerified) {
+        this.email_verified = emailVerified;
+    }
+
+    // 이메일 인증 코드를 업데이트하는 메서드 추가
+    public void setEmailVerificationCode(String emailVerificationCode) {
+        this.email_verification_code = emailVerificationCode;
+    }
+
+    // 이메일 인증 코드를 가져오는 메서드 추가
+    public String getEmailVerificationCode() {
+        return this.email_verification_code;
     }
 }

--- a/src/main/java/com/HHive/hhive/domain/user/service/EmailService.java
+++ b/src/main/java/com/HHive/hhive/domain/user/service/EmailService.java
@@ -1,30 +1,30 @@
 package com.HHive.hhive.domain.user.service;
 
+import com.HHive.hhive.domain.user.repository.UserRepository;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class EmailService {
 
     private final JavaMailSender javaMailSender;
+    private final UserRepository userRepository;
 
     @Value("${EMAIL_USERNAME}")
     private String senderEmail;
 
-    private static int number;  // 랜덤 인증 코드
-
     // 랜덤 인증 코드 생성
-    public static void createNumber() {
-        number = (int)(Math.random() * (90000)) + 100000;
+    public int createNumber() {
+        return (int)(Math.random() * (90000)) + 100000;
     }
 
     // 메일 양식 작성
-    public MimeMessage createMail(String mail){
-        createNumber();  // 인증 코드 생성
+    public MimeMessage createMail(String mail, int number){
         MimeMessage message = javaMailSender.createMimeMessage();
 
         try {
@@ -33,11 +33,11 @@ public class EmailService {
             message.setSubject("[HHive] 회원가입을 위한 이메일 인증");  // 제목 설정
             String body = "";
             body += "<h1>" + "안녕하세요. HHive 입니다." + "</h1>";
-            body += "<h2>" + "회원가입을 위해 요청하신 인증 번호입니다." + "</h2><br>";
-            body += "<h2>" + "아래 코드를 회원가입 창으로 돌아가 입력해주세요." + "</h2>";
+            body += "<h2>" + "요청하신 인증 번호입니다." + "</h2><br>";
+            body += "<h2>" + "아래 코드를 입력해주세요." + "</h2>";
 
             body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
-            body += "<h2>" + "회원가입 인증 코드입니다." + "</h2>";
+            body += "<h2>" + "이메일 인증 코드입니다." + "</h2>";
             body += "<h1 style='color:blue'>" + number + "</h1>";
             body += "</div><br>";
             body += "<h3>" + "HHive를 이용해주셔서 감사합니다." + "</h3>";
@@ -49,15 +49,21 @@ public class EmailService {
         return message;
     }
 
-    // 실제 메일 전송
-    public int sendEmail(String userId) {
+    // 이메일 전송 및 인증 코드 반환
+    @Transactional
+    public int sendEmail(String email) {
+        // 이메일 인증 코드 생성
+        int verificationCode = createNumber();
+        String code = String.valueOf(verificationCode);
 
         // 메일 전송에 필요한 정보 설정
-        MimeMessage message = createMail(userId);
+        MimeMessage message = createMail(email, verificationCode);
         // 실제 메일 전송
         javaMailSender.send(message);
 
-        // 인증 코드 반환
-        return number;
+        return verificationCode;
     }
+
+
 }
+

--- a/src/main/java/com/HHive/hhive/domain/user/service/UserService.java
+++ b/src/main/java/com/HHive/hhive/domain/user/service/UserService.java
@@ -31,6 +31,8 @@ public class UserService {
 
     private final HiveUserService hiveUserService;
 
+    private final EmailService emailService;
+
     @Transactional
     public void signup(UserSignupRequestDTO requestDTO) {
         String username = requestDTO.getUsername();
@@ -191,5 +193,37 @@ public class UserService {
         userRepository.save(user);
 
         return new UserCategoryResponseDTO(user.getMajorCategory(), user.getSubCategory());
+    }
+
+    // 이메일 인증 요청
+    @Transactional
+    public void requestEmailVerification(Long userId, int verificationCode) {
+        User user = getUser(userId);
+
+        // User 엔터티의 email_verification_code 필드를 업데이트
+        user.setEmailVerificationCode(String.valueOf(verificationCode));
+    }
+
+    // 이메일 인증 코드 검증
+    @Transactional
+    public void verifyEmail(Long userId, String inputCode) {
+        User user = getUser(userId);
+
+        // 입력한 코드와 User 엔터티의 email_verification_code를 비교
+        if (!inputCode.equals(user.getEmailVerificationCode())) {
+            throw new InvalidEmailVerificationCodeException();
+        }
+
+        // 코드가 일치하면 email_verified 값을 true로 업데이트
+        user.setEmailVerified(true);
+    }
+
+    // email_verification_code 필드 업데이트
+    @Transactional
+    public void updateEmailVerificationCode(Long userId, String code) {
+
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        user.setEmailVerificationCode(code);
     }
 }

--- a/src/main/java/com/HHive/hhive/domain/user/service/UserService.java
+++ b/src/main/java/com/HHive/hhive/domain/user/service/UserService.java
@@ -188,8 +188,8 @@ public class UserService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER_EXCEPTION));
-        user.setMajorCategory(MajorCategory.valueOf(requestDTO.getMajorCategory()));
-        user.setSubCategory(SubCategory.valueOf(requestDTO.getSubCategory()));
+        user.setMajorCategory(MajorCategory.findByTitle(requestDTO.getMajorCategory()));
+        user.setSubCategory(SubCategory.findByTitle(requestDTO.getSubCategory()));
         userRepository.save(user);
 
         return new UserCategoryResponseDTO(user.getMajorCategory(), user.getSubCategory());

--- a/src/main/java/com/HHive/hhive/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/HHive/hhive/global/exception/common/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     AUTHENTICATION_MISMATCH_EXCEPTION(401, "권한이 없습니다."),
     PASSWORD_CONFIRMATION_EXCEPTION(401, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     NOT_FOUND_USER_EXCEPTION(400, "해당 유저가 존재하지 않습니다"),
+    INVALID_EMAIL_VERIFICATION_CODE_EXCEPTION(400, "입력하신 이메일 인증 코드가 유효하지 않습니다"),
 
     //Hive
     ALREADY_EXIST_HIVE_EXCEPTION(401, "중복된 타이틀입니다."),

--- a/src/main/java/com/HHive/hhive/global/exception/user/InvalidEmailVerificationCodeException.java
+++ b/src/main/java/com/HHive/hhive/global/exception/user/InvalidEmailVerificationCodeException.java
@@ -1,0 +1,11 @@
+package com.HHive.hhive.global.exception.user;
+
+import com.HHive.hhive.global.exception.common.CustomException;
+import com.HHive.hhive.global.exception.common.ErrorCode;
+
+public class InvalidEmailVerificationCodeException extends CustomException {
+
+    public InvalidEmailVerificationCodeException() {
+        super(ErrorCode.INVALID_EMAIL_VERIFICATION_CODE_EXCEPTION);
+    }
+}


### PR DESCRIPTION
1. 사용자가 회원가입 페이지에서 회원가입을 완료하면, 백엔드에서는 회원 정보를 데이터베이스에 저장하고, 이메일 인증 코드를 생성
2. 생성된 이메일 인증 코드는 사용자의 이메일로 전송됩니다. 이 과정에서 이메일 서비스 (EmailService)가 사용됨
3. 사용자가 이메일 인증 코드를 받아서 회원가입 페이지 또는 프로필 페이지에서 이를 입력하면, 백엔드에서는 사용자가 입력한 이메일 인증 코드와 데이터베이스에 저장된 이메일 인증 코드를 비교하여 인증을 확인
4. 이메일 인증 코드가 일치하면, 사용자의 이메일 인증 상태를 true로 업데이트
5. 이메일 인증 코드가 일치하지 않으면, InvalidEmailVerificationCodeException 예외 발생

추후에 레디스를 사용하면, 이메일 인증 코드의 저장과 관리가 더 효율적으로 이루어질 수 있을 것 같습니다. ~~레디스 화이팅~~
테스트는 성공적으로 통과했고, 결과화면은 슬랙에 남겨두었습니다.
또한, API도 조금 수정이 되었으니 노션을 확인해주시면 감사하겠습니다


----
* substring 추가
* 카테고리 한글 입력 가능 추가